### PR TITLE
Update to support LuckPerms v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,204 @@
+
+# Created by https://www.gitignore.io/api/java,eclipse,intellij+all,gradle
+# Edit at https://www.gitignore.io/?templates=java,eclipse,intellij+all,gradle
+
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+### Eclipse Patch ###
+# Eclipse Core
+.project
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Annotation Processing
+.apt_generated
+
+.sts4-cache/
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+### Gradle ###
+.gradle
+build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+# gradle/wrapper/gradle-wrapper.properties
+
+### Gradle Patch ###
+**/build/
+
+# End of https://www.gitignore.io/api/java,eclipse,intellij+all,gradle

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'com.velocitypowered:velocity-api:1.0.1-SNAPSHOT'
-    compileOnly 'me.lucko.luckperms:luckperms-api:4.3'
+    compileOnly 'com.velocitypowered:velocity-api:1.0.5-SNAPSHOT'
+    compileOnly 'net.luckperms:api:5.0'
     compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1'
     compile group: 'com.cedarsoftware', name: 'json-io', version: '4.5.0'
 }

--- a/src/main/java/com/aang23/globaltab/CommandGlobalTab.java
+++ b/src/main/java/com/aang23/globaltab/CommandGlobalTab.java
@@ -21,13 +21,14 @@ public class CommandGlobalTab implements Command {
                         Integer.parseInt((String) ConfigManager.config.get("updatedelay")) * 1000,
                         Integer.parseInt((String) ConfigManager.config.get("updatedelay")) * 1000);
 
-                source.sendMessage(TextComponent.of("Restarted the tab !").color(TextColor.GREEN));
+                source.sendMessage(TextComponent.of("Restarted the tablist updater.").color(TextColor.GREEN));
             } else if (args[0].equals("config")) {
                 ConfigManager.setupConfig();
 
-                source.sendMessage(TextComponent.of("Reloaded the configuration file !").color(TextColor.GREEN));
+                source.sendMessage(TextComponent.of("Reloaded the configuration file.").color(TextColor.GREEN));
             }
-        } else
-            source.sendMessage(TextComponent.of("Usage : /globaltab restart/config").color(TextColor.RED));
+        } else {
+            source.sendMessage(TextComponent.of("Usage : /globaltab <restart/config>").color(TextColor.RED));
+        }
     }
 }

--- a/src/main/java/com/aang23/globaltab/GlobalTab.java
+++ b/src/main/java/com/aang23/globaltab/GlobalTab.java
@@ -2,50 +2,43 @@ package com.aang23.globaltab;
 
 import com.google.common.io.ByteArrayDataInput;
 import com.google.inject.Inject;
+import com.velocitypowered.api.command.CommandManager;
+import com.velocitypowered.api.event.EventManager;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.DisconnectEvent;
+import com.velocitypowered.api.event.connection.PluginMessageEvent;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.ServerConnection;
-import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.messages.LegacyChannelIdentifier;
 import com.velocitypowered.api.proxy.player.TabList;
 import com.velocitypowered.api.proxy.player.TabListEntry;
-import com.velocitypowered.api.proxy.server.RegisteredServer;
-import com.velocitypowered.api.proxy.server.ServerInfo;
-import com.velocitypowered.api.proxy.server.ServerPing;
-
-import org.slf4j.Logger;
-import me.lucko.luckperms.LuckPerms;
-import me.lucko.luckperms.api.LuckPermsApi;
-import com.velocitypowered.api.command.CommandManager;
-import com.velocitypowered.api.event.EventManager;
-import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
-import com.velocitypowered.api.event.Subscribe;
-import com.velocitypowered.api.plugin.annotation.DataDirectory;
-import com.velocitypowered.api.event.connection.DisconnectEvent;
-import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
+import org.slf4j.Logger;
 
-@Plugin(id = "globaltab", name = "GlobalTab", version = "1.0", description = "A plugin", authors = { "Aang23" })
+@Plugin(id = "globaltab", name = "GlobalTab", version = "1.0", description = "A tab list plugin for Velocity", authors = {"Aang23"})
 public class GlobalTab {
     public static ProxyServer server;
     public static Logger logger;
     public static Path configspath;
-    public static LuckPermsApi luckpermsapi;
+    public static LuckPerms lpApi;
 
     public static Map<String, Double> playerBalances = new HashMap<String, Double>();
 
     @Inject
     public GlobalTab(ProxyServer lserver, CommandManager commandManager, EventManager eventManager, Logger llogger,
-            @DataDirectory Path configpaths) {
+                     @DataDirectory Path configpaths) {
 
         server = lserver;
         logger = llogger;
@@ -58,14 +51,38 @@ public class GlobalTab {
 
         Timer timer = new Timer();
         timer.scheduleAtFixedRate(new TimerHandler(),
-                Integer.parseInt((String) ConfigManager.config.get("updatedelay")) * 1000,
-                Integer.parseInt((String) ConfigManager.config.get("updatedelay")) * 1000);
+            Integer.parseInt((String) ConfigManager.config.get("updatedelay")) * 1000,
+            Integer.parseInt((String) ConfigManager.config.get("updatedelay")) * 1000);
+    }
+
+    public static void insertIntoTabListCleanly(TabList list, TabListEntry entry, List<UUID> toKeep) {
+        UUID inUUID = entry.getProfile().getId();
+        List<UUID> containedUUIDs = new ArrayList<UUID>();
+        Map<UUID, TabListEntry> cache = new HashMap<UUID, TabListEntry>();
+        for (TabListEntry current : list.getEntries()) {
+            containedUUIDs.add(current.getProfile().getId());
+            cache.put(current.getProfile().getId(), current);
+        }
+        if (!containedUUIDs.contains(inUUID)) {
+            list.addEntry(entry);
+            toKeep.add(inUUID);
+        } else {
+            TabListEntry currentEntr = cache.get(inUUID);
+            if (!currentEntr.getDisplayName().equals(entry.getDisplayName())) {
+                list.removeEntry(inUUID);
+                list.addEntry(entry);
+                toKeep.add(inUUID);
+            } else {
+                toKeep.add(inUUID);
+            }
+        }
     }
 
     @Subscribe
     public void onInitialization(ProxyInitializeEvent event) {
-        if (GlobalTab.server.getPluginManager().isLoaded("luckperms"))
-            luckpermsapi = LuckPerms.getApi();
+        if (GlobalTab.server.getPluginManager().isLoaded("luckperms")) {
+            lpApi = LuckPermsProvider.get();
+        }
     }
 
     @Subscribe
@@ -102,33 +119,11 @@ public class GlobalTab {
             String packet[] = in.readUTF().split(":");
             String username = packet[0];
             Double balance = Double.parseDouble(packet[1]);
-            if (playerBalances.containsKey(username))
+            if (playerBalances.containsKey(username)) {
                 playerBalances.replace(username, balance);
-            else
+            } else {
                 playerBalances.put(username, balance);
-        }
-    }
-
-    public static void insertIntoTabListCleanly(TabList list, TabListEntry entry, List<UUID> toKeep) {
-        UUID inUUID = entry.getProfile().getId();
-        List<UUID> containedUUIDs = new ArrayList<UUID>();
-        Map<UUID, TabListEntry> cache = new HashMap<UUID, TabListEntry>();
-        for (TabListEntry current : list.getEntries()) {
-            containedUUIDs.add(current.getProfile().getId());
-            cache.put(current.getProfile().getId(), current);
-        }
-        if (!containedUUIDs.contains(inUUID)) {
-            list.addEntry(entry);
-            toKeep.add(inUUID);
-            return;
-        } else {
-            TabListEntry currentEntr = cache.get(inUUID);
-            if (!currentEntr.getDisplayName().equals(entry.getDisplayName())) {
-                list.removeEntry(inUUID);
-                list.addEntry(entry);
-                toKeep.add(inUUID);
-            } else
-                toKeep.add(inUUID);
+            }
         }
     }
 }

--- a/src/main/java/com/aang23/globaltab/UserInfoGetter.java
+++ b/src/main/java/com/aang23/globaltab/UserInfoGetter.java
@@ -1,37 +1,26 @@
 package com.aang23.globaltab;
 
-import me.lucko.luckperms.api.Contexts;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.query.QueryOptions;
 
 public class UserInfoGetter {
     public static String getPrefixFromUsername(String username) {
         if (GlobalTab.server.getPluginManager().isLoaded("luckperms")) {
-            if (GlobalTab.luckpermsapi.getUserSafe(username).isPresent()) {
-                Contexts contexts = GlobalTab.luckpermsapi.getContextForUser(GlobalTab.luckpermsapi.getUser(username))
-                        .get();
-                if (GlobalTab.luckpermsapi.getUser(username).getCachedData().getMetaData(contexts).getPrefix() != null)
-                    return GlobalTab.luckpermsapi.getUser(username).getCachedData().getMetaData(contexts).getPrefix()
-                            .toString();
-                else
-                    return "";
-            } else
-                return "";
-        } else
-            return "";
+            User lpUser = GlobalTab.lpApi.getUserManager().getUser(username);
+            if (lpUser != null) {
+                return lpUser.getCachedData().getMetaData(QueryOptions.defaultContextualOptions()).getPrefix();
+            }
+        }
+        return "";
     }
 
     public static String getSuffixFromUsername(String username) {
         if (GlobalTab.server.getPluginManager().isLoaded("luckperms")) {
-            if (GlobalTab.luckpermsapi.getUserSafe(username).isPresent()) {
-                Contexts contexts = GlobalTab.luckpermsapi.getContextForUser(GlobalTab.luckpermsapi.getUser(username))
-                        .get();
-                if (GlobalTab.luckpermsapi.getUser(username).getCachedData().getMetaData(contexts).getSuffix() != null)
-                    return GlobalTab.luckpermsapi.getUser(username).getCachedData().getMetaData(contexts).getSuffix()
-                            .toString();
-                else
-                    return "";
-            } else
-                return "";
-        } else
-            return "";
+            User lpUser = GlobalTab.lpApi.getUserManager().getUser(username);
+            if (lpUser != null) {
+                return lpUser.getCachedData().getMetaData(QueryOptions.defaultContextualOptions()).getSuffix();
+            }
+        }
+        return "";
     }
 }

--- a/src/main/java/com/aang23/globaltab/UserInfoGetter.java
+++ b/src/main/java/com/aang23/globaltab/UserInfoGetter.java
@@ -8,7 +8,10 @@ public class UserInfoGetter {
         if (GlobalTab.server.getPluginManager().isLoaded("luckperms")) {
             User lpUser = GlobalTab.lpApi.getUserManager().getUser(username);
             if (lpUser != null) {
-                return lpUser.getCachedData().getMetaData(QueryOptions.defaultContextualOptions()).getPrefix();
+                String prefix = lpUser.getCachedData().getMetaData(QueryOptions.defaultContextualOptions()).getPrefix();
+                if (prefix != null) {
+                    return prefix;
+                }
             }
         }
         return "";
@@ -18,7 +21,10 @@ public class UserInfoGetter {
         if (GlobalTab.server.getPluginManager().isLoaded("luckperms")) {
             User lpUser = GlobalTab.lpApi.getUserManager().getUser(username);
             if (lpUser != null) {
-                return lpUser.getCachedData().getMetaData(QueryOptions.defaultContextualOptions()).getSuffix();
+                String suffix = lpUser.getCachedData().getMetaData(QueryOptions.defaultContextualOptions()).getSuffix();
+                if (suffix != null) {
+                    return suffix;
+                }
             }
         }
         return "";


### PR DESCRIPTION
Previously, attempting to start the proxy with LuckPerms v5 and GlobalTab installed led to an instant error as GlobalTab used the old LP v4.3 API. This PR updates the plugin to use LP v5's API.

**Edit:** Here's a test jar for those interested: [GlobalTab-1.0-pr7.zip](https://github.com/Aang23/GlobalTab/files/4135448/GlobalTab-1.0-pr7.zip)

